### PR TITLE
Implement NixOS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,15 @@ Runtime env variables:
         ({config, ...}: {
           services.ddns-my-public-ip = {
             enable = true;
-            domains = "a.example.com,b.example.com";
-            # ... TODO: Add config options sample from the module.
+
+            dnsServer = "example.com";
+            dnsZone = "site1.example.com";
+            domains = "ip.site1.example.com";
+            ttl = 60;
+            tsigHmac = "hmac-sha256";
+            tsigKey = "mykey";
+            tsigSecret = "dGVzdC10c2lnLXNlY3JldAo=";
+            timerInterval = "1min";
           };
         })
       ];

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ used, thanks!
 
 ## Config
 
-Use env variables:
+Buildtime env variables:
+
+- `NSUPDATE`: The `nsupdate` binary to use (default `nsupdate`)
+
+Runtime env variables:
 
 - `DNS_SERVER`: DNS server to update
 - `DNS_ZONE`: DNS zone to update (no trailing dot)
@@ -17,7 +21,6 @@ Use env variables:
 - `TSIG_HMAC`: TSIG HMAC algorithm, e.g. `hmac-sha256`
 - `TSIG_KEY`: TSIG key name
 - `TSIG_SECRET`: TSIG key secret (base64)
-- `NSUPDATE`: The `nsupdate` binary to use (default `nsupdate`)
 
 
 ## Use with NixOS (Flakes)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,29 @@ Use env variables:
 - `TSIG_KEY`: TSIG key name
 - `TSIG_SECRET`: TSIG key secret (base64)
 - `NSUPDATE`: The `nsupdate` binary to use (default `nsupdate`)
+
+
+## Use with NixOS (Flakes)
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    ddns-my-public-ip.url = "github:dbrgn/ddns-my-public-ip";
+  };
+  outputs = {nixpkgs, ddns-my-public-ip, ...}: {
+    nixosConfigurations.my-hostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        ddns-my-public-ip.nixosModules.default
+        ({config, ...}: {
+          services.ddns-my-public-ip = {
+            enable = true;
+            domains = "a.example.com,b.example.com";
+            # ... TODO: Add config options sample from the module.
+          };
+        })
+      ];
+    };
+  };
+}
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Runtime env variables:
 
             dnsServer = "example.com";
             dnsZone = "site1.example.com";
-            domains = "ip.site1.example.com";
+            domains = ["ip.site1.example.com" "webcam.site1.example.com"];
             ttl = 60;
             tsigHmac = "hmac-sha256";
             tsigKey = "mykey";

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       # Supported target systems
       allSystems = [
@@ -14,41 +15,23 @@
       ];
 
       # Helper to build a package for all supported systems above
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit system; };
-      });
+      forAllSystems =
+        f: nixpkgs.lib.genAttrs allSystems (system: f { pkgs = import nixpkgs { inherit system; }; });
+
+      mkPackage = pkgs: pkgs.callPackage ./package.nix { };
     in
     {
-      # options = {
-      #   dnsServer = lib.mkOption {
-      #     type = lib.types.str;
-      #     description = "DNS server to update";
-      #     example = "example.com";
-      #   };
-      #   dnsZone = lib.mkOption {
-      #     type = lib.types.str;
-      #     description = "DNS zone to update (no trailing dot)";
-      #     example = "site1.example.com";
-      #   };
-      #   domains = lib.mkOption {
-      #     type = lib.types.str;
-      #     description = "Comma-separated list of domains to update (no trailing dot)";
-      #     example = "ip.site1.example.com,webcam.site1.example.com";
-      #   };
-      # };
+      formatter = forAllSystems ({ pkgs }: pkgs.nixfmt-rfc-style);
 
-      packages = forAllSystems ({ pkgs }: {
-        default = pkgs.rustPlatform.buildRustPackage {
-          pname = "ddns-my-public-ip";
-          version = "0.1.0";
-          src = self;
-          cargoLock.lockFile = ./Cargo.lock;
-          buildInputs = [ pkgs.bind ]; # Dependency: nsupdate
-          shellHook = ''
-            export NSUPDATE="${pkgs.bind}"
-            export DNS_SERVER="${pkgs.bind}"
-          '';
-        };
-      });
+      nixosModules.default = import ./nixos-module.nix self;
+
+      overlays.default = final: _prev: { ddns-my-public-ip = mkPackage final; };
+
+      packages = forAllSystems (
+        { pkgs }:
+        {
+          default = mkPackage pkgs;
+        }
+      );
     };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,0 +1,76 @@
+self:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.ddns-my-public-ip;
+in
+with lib;
+{
+  options.services.ddns-my-public-ip = {
+    enable = mkEnableOption "DDNS My Public IP";
+    package = mkPackageOption pkgs "ddns-my-public-ip" { };
+
+    dnsServer = mkOption {
+      type = types.str;
+      description = "DNS server to update";
+      example = "example.com";
+    };
+    dnsZone = mkOption {
+      type = types.str;
+      description = "DNS zone to update (no trailing dot)";
+      example = "site1.example.com";
+    };
+    domains = mkOption {
+      type = types.str;
+      description = "Comma-separated list of domains to update (no trailing dot)";
+      example = "ip.site1.example.com,webcam.site1.example.com";
+    };
+    environmentFile = mkOption {
+      description = ''
+        Path to an EnvironmentFile containing required environment
+        variables as per documentation.
+      '';
+      type = types.path;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    nixpkgs.overlays = [ self.overlays.default ];
+
+    systemd.services.ddns-my-public-ip = {
+      # TODO: Full service configuration (run after network-online, etc etc).
+      #       See https://search.nixos.org/options?channel=24.11&from=0&size=100&sort=relevance&type=packages&query=systemd.services.%3Cname%3E
+      #       Example here (not oneShot, but otherwise nice with temp. user): https://github.com/zhaofengli/attic/blob/main/nixos/atticd.nix#L200
+      description = "";
+      wants = [ "network-online.target" ];
+
+      environment = {
+        DNS_SERVER = cfg.dnsServer;
+        DNS_ZONE = cfg.dnsZone;
+        DOMAINS = cfg.domains;
+      };
+
+      serviceConfig = {
+        ExecStart = "${getExe cfg.package}";
+        EnvironmentFile = cfg.environmentFile;
+      };
+    };
+
+    systemd.timers.ddns-my-public-ip = {
+      # TODO: See https://search.nixos.org/options?channel=24.11&from=0&size=100&sort=relevance&type=packages&query=systemd.timer
+      description = "";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.startAt; # TODO: Config option?
+      };
+
+      # Wait for network before running
+      after = "network-online.target";
+      wants = "network-online.target";
+    };
+  };
+}

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -25,10 +25,10 @@ in
       description = "DNS zone to update (no trailing dot)";
       example = "site1.example.com";
     };
-    domains = mkOption { # TODO make this a list
-      type = types.str;
-      description = "Comma-separated list of domains to update (no trailing dot)";
-      example = "ip.site1.example.com,webcam.site1.example.com";
+    domains = mkOption {
+      type = types.listOf types.str;
+      description = "List of domains to update (no trailing dot)";
+      example = ["ip.site1.example.com" "webcam.site1.example.com"];
     };
     ttl = mkOption {
       type = types.int;
@@ -72,7 +72,7 @@ in
       environment = {
         DNS_SERVER = cfg.dnsServer;
         DNS_ZONE = cfg.dnsZone;
-        DOMAINS = cfg.domains;
+        DOMAINS = concatStringsSep "," cfg.domains;
         TTL = toString cfg.ttl;
         TSIG_HMAC = cfg.tsigHmac;
         TSIG_KEY = cfg.tsigKey;

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -46,10 +46,12 @@ in
       description = "Key name for TSIG authentication";
       example = "my-tsig-key";
     };
-    tsigSecret = mkOption {
+    tsigSecretFile = mkOption {
       type = types.str;
-      description = "TSIG secret (base64-encoded)";
-      example = "c2VjcmV0c2VjcmV0OTM4NzQ5ODI3MzQ5ODcyMwo=";
+      description = "Path to EnvironmentFile with TSIG_SECRET env variable (base64-encoded)";
+      example = ''
+        Path to file containing `TSIG_SECRET="c2VjcmV0c2VjcmV0OTM4NzQ5ODI3MzQ5ODcyMwo="`
+      '';
     };
     timerInterval = mkOption {
       type = types.str;
@@ -76,12 +78,12 @@ in
         TTL = toString cfg.ttl;
         TSIG_HMAC = cfg.tsigHmac;
         TSIG_KEY = cfg.tsigKey;
-        TSIG_SECRET = cfg.tsigSecret;
       };
 
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${cfg.package}/bin/ddns-my-public-ip";
+        EnvironmentFile = [ tsigSecretFile ];
       };
     };
 

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -28,7 +28,10 @@ in
     domains = mkOption {
       type = types.listOf types.str;
       description = "List of domains to update (no trailing dot)";
-      example = ["ip.site1.example.com" "webcam.site1.example.com"];
+      example = [
+        "ip.site1.example.com"
+        "webcam.site1.example.com"
+      ];
     };
     ttl = mkOption {
       type = types.int;

--- a/package.nix
+++ b/package.nix
@@ -6,7 +6,6 @@ rustPlatform.buildRustPackage {
   cargoLock.lockFile = ./Cargo.lock;
   buildInputs = [ bind ]; # Dependency: nsupdate
   shellHook = ''
-    export NSUPDATE="${bind}"
-    export DNS_SERVER="${bind}"
+    export NSUPDATE="${bind}/nsupdate"
   '';
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,12 @@
+{ rustPlatform, bind, ... }:
+rustPlatform.buildRustPackage {
+  pname = "ddns-my-public-ip";
+  version = "0.1.0";
+  src = ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+  buildInputs = [ bind ]; # Dependency: nsupdate
+  shellHook = ''
+    export NSUPDATE="${bind}"
+    export DNS_SERVER="${bind}"
+  '';
+}

--- a/package.nix
+++ b/package.nix
@@ -4,8 +4,8 @@ rustPlatform.buildRustPackage {
   version = "0.1.0";
   src = ./.;
   cargoLock.lockFile = ./Cargo.lock;
-  buildInputs = [ bind ]; # Dependency: nsupdate
-  shellHook = ''
-    export NSUPDATE="${bind}/nsupdate"
+  buildInputs = [ bind.dnsutils ]; # Dependency: nsupdate
+  preBuild = ''
+    export NSUPDATE="${bind.dnsutils}/bin/nsupdate"
   '';
 }


### PR DESCRIPTION
Adds an incomplete (and untested) NixOS module implementation as inspiration :slightly_smiling_face: 

I assumed in the module that the ENV variables get passed at runtime by systemd - adding parameters for the build is not really intended by flakes (to enable reproducibility).

if you really want to pass the arguments at compile time, then IMHO the right way to do this under NixOS is to use the nixpkgs overlay pattern to change build parameters (works nicely with [the callPackage pattern](https://nix.dev/tutorials/callpackage) that I added in this MR) . This could be implemented in `nixos-modules.nix` as well.  
Note that in this case, `TSIG_SECRET` would be stored world-readable in the nix store.